### PR TITLE
TFXAGA: RC6

### DIFF
--- a/T/TFX/usr/source/serial.s
+++ b/T/TFX/usr/source/serial.s
@@ -1,3 +1,7 @@
+        IFND SER_OUTPUT
+SER_OUTPUT=0
+        ENDC
+
         IFEQ SER_OUTPUT
 PRINT_MSG macro
         endm


### PR DESCRIPTION
- Fix slowdown when waiting to swap screen
- FPS counter uses ReadEClock
- Auto mode selects "TFX" if "fast mode"
- Enable chip data cache in fast mode
- Use PL_GA instead of custom code
- Option to directly start action (useful for debugging)
- Option to disable FPS cap